### PR TITLE
Patch 1 - Added missing scss files to import

### DIFF
--- a/styles/sass/custom/custom.scss
+++ b/styles/sass/custom/custom.scss
@@ -45,10 +45,13 @@
 @import "pagetemplates/tablet/tablet-page-dashboard";
 @import "pagetemplates/tablet/tablet-page-form";
 @import "pagetemplates/tablet/tablet-page-masterdetail";
+@import "pagetemplates/tablet/tablet-page-tabs";
 @import "pagetemplates/tablet/tablet-page-wizard";
+
 
 // Building Blocks
 @import "buildingblocks/card";
+@import "buildingblocks/controlbar";
 @import "buildingblocks/dashboardcard";
 @import "buildingblocks/dashboardstat";
 @import "buildingblocks/form";

--- a/styles/sass/custom/custom.scss
+++ b/styles/sass/custom/custom.scss
@@ -48,7 +48,6 @@
 @import "pagetemplates/tablet/tablet-page-tabs";
 @import "pagetemplates/tablet/tablet-page-wizard";
 
-
 // Building Blocks
 @import "buildingblocks/card";
 @import "buildingblocks/controlbar";


### PR DESCRIPTION
It goes for these files (missing import lines):
- buildingblocks/controlbar
- pagetemplates/tablet/tablet-page-tabs